### PR TITLE
feat: upgrade to support sumac release

### DIFF
--- a/appsembler_api/apidocs.md
+++ b/appsembler_api/apidocs.md
@@ -190,16 +190,16 @@ The endpoint can update email, all available profile fields and also has support
         * `name` # user full name
         * `country` # country iso code, ex: `ES`, `UY`, `US`
         * `gender` # user gender, accepted values `m`, `f` or `o`
-        * `level_of_education` # user education, accepted values `p`, `m`, `b`, `a`, `hs`, `jhs`, `el`, `none` or `other`, 
+        * `level_of_education` # user education, accepted values `p`, `m`, `b`, `a`, `hs`, `jhs`, `el`, `none` or `other`,
         * `year_of_birth` # four digit year as string
         * `city` # text
-        * `mailing_address` # long text 
+        * `mailing_address` # long text
         * `language` # language iso code, ex 'ES', 'EN'
         * `goals` # long text
         * `bio` # text
 
-You also can send extended profile form fiels, but that depends on every installation, you'll need to find the [registration extension form app fork](https://github.com/open-craft/custom-form-app) that is installed on the instance, and check the field names, and accepted values. 
-        
+You also can send extended profile form fiels, but that depends on every installation, you'll need to find the [registration extension form app fork](https://github.com/open-craft/custom-form-app) that is installed on the instance, and check the field names, and accepted values.
+
 * Success Response
 	* Code: 200
 	* Content: Success message and list of updated fields and values
@@ -225,7 +225,7 @@ Authorization: Bearer cbf6a5de322cf6a4323c957a882xy1s321c954b86
 Cache-Control: no-cache
 {
 	"user_lookup": "staff@example.com",
-	"emai": "new_staff@example.com",
+	"email": "new_staff@example.com",
 	"name": "Staff New Name",
 	"country": "US",
 	"gender": "f",

--- a/appsembler_api/urls.py
+++ b/appsembler_api/urls.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long,
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.db import transaction
 
 from openedx.core.djangoapps.user_authn.views import login
@@ -10,39 +10,39 @@ from appsembler_api import views
 
 urlpatterns = [
     # provide a wrapped cross-domain csrf version of user_api/v1/account/login_session
-    # use an Nginx redirect from that to 
+    # use an Nginx redirect from that to
     # /appsembler_api/v0/account/login_session if you want to use this one:
     # override of login_session from openedx.core.djangoapps.user_authn.urls_common
-    url(r'^account/login_session/$', ensure_csrf_cookie_cross_domain(login.LoginSessionView.as_view()),
-        name="user_api_login_session"
+    re_path(r'^account/login_session/$', ensure_csrf_cookie_cross_domain(login.LoginSessionView.as_view()),
+        kwargs={"api_version": "v1"}, name="user_api_login_session"
     ),
 
     # user API
-    url(
+    re_path(
         r'^accounts/user_without_password',
         transaction.non_atomic_requests(views.CreateUserAccountWithoutPasswordView.as_view()),
         name="create_user_account_without_password_api"
     ),
-    url(r'^accounts/create', 
+    re_path(r'^accounts/create',
         transaction.non_atomic_requests(views.CreateUserAccountView.as_view()),
         name="create_user_account_api"
     ),
-    url(r'^accounts/connect', views.UserAccountConnect.as_view(), name="user_account_connect_api"),
-    url(r'^accounts/update_user', views.UpdateUserAccount.as_view(), name="user_account_update_user"),
-    url(r'^accounts/get-user/(?P<username>[\w.+-]+)', views.GetUserAccountView.as_view(), name="get_user_account_api"),
+    re_path(r'^accounts/connect', views.UserAccountConnect.as_view(), name="user_account_connect_api"),
+    re_path(r'^accounts/update_user', views.UpdateUserAccount.as_view(), name="user_account_update_user"),
+    re_path(r'^accounts/get-user/(?P<username>[\w.+-]+)', views.GetUserAccountView.as_view(), name="get_user_account_api"),
 
     # Just like CourseListView API, but with search
-    url(r'^search_courses', views.CourseListSearchView.as_view(), name="course_list_search"),
+    re_path(r'^search_courses', views.CourseListSearchView.as_view(), name="course_list_search"),
 
     # bulk enrollment API
-    url(r'^bulk-enrollment/bulk-enroll', views.BulkEnrollView.as_view(), name="bulk_enrollment_api"),
+    re_path(r'^bulk-enrollment/bulk-enroll', views.BulkEnrollView.as_view(), name="bulk_enrollment_api"),
 
     # enrollment codes API
-    url(r'^enrollment-codes/generate', views.GenerateRegistrationCodesView.as_view(), name="generate_registration_codes_api"),  # pylint: disable=line-too-long
-    url(r'^enrollment-codes/enroll-user', views.EnrollUserWithEnrollmentCodeView.as_view(), name="enroll_use_with_code_api"),  # pylint: disable=line-too-long
-    url(r'^enrollment-codes/status', views.EnrollmentCodeStatusView.as_view(), name="enrollment_code_status_api"),
+    re_path(r'^enrollment-codes/generate', views.GenerateRegistrationCodesView.as_view(), name="generate_registration_codes_api"),  # pylint: disable=line-too-long
+    re_path(r'^enrollment-codes/enroll-user', views.EnrollUserWithEnrollmentCodeView.as_view(), name="enroll_use_with_code_api"),  # pylint: disable=line-too-long
+    re_path(r'^enrollment-codes/status', views.EnrollmentCodeStatusView.as_view(), name="enrollment_code_status_api"),
 
     # enrollment analytics API
-    url(r'^analytics/accounts/batch', views.GetBatchUserDataView.as_view(), name="get_batch_user_data"),
-    url(r'^analytics/enrollment/batch', views.GetBatchEnrollmentDataView.as_view(), name="get_batch_enrollment_data"),
+    re_path(r'^analytics/accounts/batch', views.GetBatchUserDataView.as_view(), name="get_batch_user_data"),
+    re_path(r'^analytics/enrollment/batch', views.GetBatchEnrollmentDataView.as_view(), name="get_batch_enrollment_data"),
 ]

--- a/appsembler_api/utils.py
+++ b/appsembler_api/utils.py
@@ -7,10 +7,32 @@ from random import randint
 from django.conf import settings
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
-from openedx.core.djangoapps.appsembler.api.v1.api import account_exists
+from common.djangoapps.student.models import email_exists_or_retired, username_exists_or_retired
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.views.password_reset import PasswordResetFormNoActive
 
+def account_exists(email, username):
+    # source: https://github.com/appsembler/edx-platform/blob/appsembler/psu-temp-tahoe-juniper/openedx/core/djangoapps/appsembler/api/v1/api.py#L35-L55
+    """Check if an account exists for either the email or the username
+
+    Both email and username are required as parameters, but either or both can
+    be None
+
+    Do we need to check secondary email? If so then check if the email exists:
+    ```
+    from student.models import AccountRecovery
+    AccountRecovery.objects.filter(secondary_email=email).exists()
+    ```
+    """
+    if email and email_exists_or_retired(email):
+        email_exists = True
+    else:
+        email_exists = False
+    if username and username_exists_or_retired(username):
+        username_exists = True
+    else:
+        username_exists = False
+    return email_exists or username_exists
 
 
 def auto_generate_username(email):

--- a/appsembler_api/views.py
+++ b/appsembler_api/views.py
@@ -5,8 +5,8 @@ import random
 import string
 
 import search
-from course_modes.models import CourseMode
-from courseware.courses import get_course_by_id
+from common.djangoapps.course_modes.models import CourseMode
+from openedx.core.lib.courses import get_course_by_id
 from dateutil import parser
 from django.contrib.auth.models import User
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
@@ -18,9 +18,8 @@ from edx_rest_framework_extensions.paginators import NamespacedPageNumberPaginat
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.course_api.api import list_courses
 from lms.djangoapps.course_api.serializers import CourseSerializer
-from lms.djangoapps.instructor.views.api import save_registration_code, students_update_enrollment
+from lms.djangoapps.instructor.views.api import students_update_enrollment
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.appsembler.api.v1.api import account_exists
 from openedx.core.djangoapps.enrollments.views import (
     ApiKeyPermissionMixIn,
     EnrollmentCrossDomainSessionAuth,
@@ -36,22 +35,18 @@ from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from shoppingcart.exceptions import RedemptionCodeError
-from shoppingcart.models import CourseRegistrationCode, RegistrationCodeRedemption
-from shoppingcart.views import get_reg_code_validity
-from student.models import (
+from common.djangoapps.student.models import (
         AlreadyEnrolledError,
         CourseEnrollment,
         CourseFullError,
         EnrollmentClosedError,
         UserProfile
 )
-from student.views import validate_new_email
-from util.disable_rate_limit import can_disable_rate_limit
-from util.request_rate_limiter import BadRequestRateLimiter
+from common.djangoapps.student.views import validate_new_email
+from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from .forms import CourseListGetAndSearchForm
 from .serializers import BulkEnrollmentSerializer
-from .utils import auto_generate_username, send_activation_email
+from .utils import auto_generate_username, send_activation_email, account_exists
 
 
 log = logging.getLogger(__name__)
@@ -408,6 +403,12 @@ class GenerateRegistrationCodesView(APIView):
     permission_classes = (IsStaffOrOwner,)
 
     def post(self, request):
+        # TODO: save_registration_code was removed in https://github.com/openedx/edx-platform/pull/24692/ | https://openedx.atlassian.net/browse/DEPR-43
+        # It's possibly replaced by equivalent things in the ecommerce app https://github.com/openedx-unsupported/ecommerce
+        # Which in turn has also been deprecated and removed in Teak.
+        # Check out https://github.com/hastexo/webhook-receiver or https://github.com/openedx/public-engineering/issues/22#issuecomment-1754239389
+        raise NotImplementedError
+
         course_id = CourseKey.from_string(request.data.get('course_id'))
 
         try:
@@ -448,6 +449,9 @@ class EnrollUserWithEnrollmentCodeView(APIView):
     permission_classes = (IsStaffOrOwner,)
 
     def post(self, request):
+        # TODO: this is also affected by the removal of commerce
+        raise NotImplementedError
+
         enrollment_code = request.data.get('enrollment_code')
         limiter = BadRequestRateLimiter()
         error_reason = ""
@@ -516,6 +520,9 @@ class EnrollmentCodeStatusView(APIView):
     permission_classes = (IsStaffOrOwner,)
 
     def post(self, request):
+        # TODO: this is also affected by the removal of commerce
+        raise NotImplementedError
+
         code = request.data.get('enrollment_code')
         action = request.data.get('action')
         try:


### PR DESCRIPTION
## Description

Upgrade the plugin to work with Open edX sumac release.

- django `url` was replaced by `re_path`
- `LoginSessionView` now requires an `api_version` argument (added via `re_path` `kwargs` kwarg)
- copy the `account_exists` function from appsembler's edx-platform branch
  so this codebase doesn't depend on that branch
- fix some import paths for some edx-platform modules
- minor docs improvements
- TEMP: disable the enrollment-codes endpoints while we figure out how to reimplement them
  since the shoppingcart app was removed from edx-platform.


Working endpoints:

- [x] /appsembler_api/v0/accounts/create
- [x] /appsembler_api/v0/accounts/user_without_password *
- [x] /appsembler_api/v0/account/login_session/
- [x] /appsembler_api/v0/accounts/get-user/<username>
- [x] /appsembler_api/v0/accounts/connect
- [x] /appsembler_api/v0/accounts/update_user
- [ ] /appsembler_api/v0/enrollment-codes/generate
- [ ] /appsembler_api/v0/enrollment-codes/enroll-user
- [ ] /appsembler_api/v0/enrollment-codes/status
- [x] /appsembler_api/v0/bulk-enrollment/bulk-enroll
- [x] /appsembler_api/v0/search_courses
- [x] /appsembler_api/v0/analytics/accounts/batch
- [x] /appsembler_api/v0/analytics/enrollment/batch

* user_without_password is slightly bugged: it uses `create_acount_with_params`, which assumes the new user is being created for the current request, which messes up the existing session. This manifests as a 401 error ever second response if cookies are being retained, although the user will still get successfully created. I expect this bug already existed in the plugin on juniper, so not an upgrade issue, and out of scope here.

## Supporting information

Private-ref: [BB-10035](https://tasks.opencraft.com/browse/BB-10035)

## Testing instructions

- install this plugin in a Sumac Tutor devstack - eg.:

```sh
git clone https://github.com/open-craft/legacy-appsembler-api
cd legacy-appsembler-api
git checkout samuel/sumac-upgrade
cd ..
tutor mounts add ./legacy-appsembler-api
tutor mounts list
notify tutor images build openedx-dev
notify tutor dev launch
```

- create and enable this single file python plugin in Tutor (otherwise Tutor won't automatically bind mount and install legacy-appsembler-api):

```python
from tutor import hooks
hooks.Filters.MOUNTED_DIRECTORIES.add_item(("openedx", "legacy-appsembler-api"))
```

- exercise all the API endpoints, as described in ./appsembler_api/apidocs.md . For convenience, here is a workspace export from Yaak with example API requests: [yaak.open-edx.json](https://github.com/user-attachments/files/22378290/yaak.open-edx.json). NOTE: the enrollment-codes endpoints aren't working yet.


## Deadline

None

## Other information

N/A