### PR TITLE
break: Reintroduce multi-redemption bug.

### DIFF
--- a/docs/manual-test-plan.md
+++ b/docs/manual-test-plan.md
@@ -568,6 +568,7 @@ Log in to the web UI as the "apicreated1@example.com" user
 (username "apicreated4"; sorry, that's confusing; password "newpassword"),
 and verify the user is enrolled in the Open edX Demo Course.
 
+**NOTE: This next test, for reusing an enrollment code, will fail. You will be able to reuse the code even though you should not be able to. See [this PR](https://github.com/open-craft/legacy-appsembler-api/pull/5) for details.**
 
 Test enrolling again with the same code:
 

--- a/shoppingcart/views.py
+++ b/shoppingcart/views.py
@@ -468,14 +468,13 @@ class EnrollUserWithEnrollmentCodeView(APIView):
             user_is_valid = False
             error_reason = "User not found"
         try:
-            reg_code_is_valid, reg_code_already_redeemed, course_registration = get_reg_code_validity(enrollment_code)
+            reg_code_is_valid, _reg_code_already_redeemed, course_registration = get_reg_code_validity(enrollment_code)
         except Http404:
             # only count toward the rate limiting if it was an invalid code
             is_ratelimited(request, key="user", group="enrollment-codes.enroll-user", rate="6/m", increment=True)
             reg_code_is_valid = False
-            reg_code_already_redeemed = False
             error_reason = "Enrollment code not found"
-        if user_is_valid and reg_code_is_valid and not reg_code_already_redeemed:
+        if user_is_valid and reg_code_is_valid:
             course = get_course_by_id(course_registration.course_id, depth=0)
             redemption = RegistrationCodeRedemption.create_invoice_generated_registration_redemption(
                 course_registration, user


### PR DESCRIPTION
## Description

This Pull Request re-introduces the multi-redemption bug that was fixed when porting the code forward, as our client's code currently relies on this behavior.

## Supporting information

Discussion where this bug was fixed: https://github.com/open-craft/legacy-appsembler-api/pull/2/files#r2362024769

Jira Ticket: https://tasks.opencraft.com/browse/BB-10094

## Testing instructions

Perform the manual tests for enrollment codes, and verify the test for re-using an enrollement code fails as the docs now specify.

## Pre-merge checklist:

- [x] `make format` has been run
- [x] This has been manually installed in a Tutor devstack and:
  - [ ] manual testing steps have been followed (as described in ./docs/manual-test-plan.md)
  - [ ] `make test_migrations` has been run
