### PR TITLE
fix: update the platform import that has changed

### DIFF
--- a/shoppingcart/views.py
+++ b/shoppingcart/views.py
@@ -1,6 +1,5 @@
 """Views for the API"""
 
-import json
 import logging
 import secrets
 import string
@@ -30,7 +29,7 @@ from edx_rest_framework_extensions.paginators import NamespacedPageNumberPaginat
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.course_api.api import list_courses
 from lms.djangoapps.course_api.serializers import CourseSerializer
-from lms.djangoapps.instructor.views.api import students_update_enrollment
+from lms.djangoapps.instructor.views.api import StudentsUpdateEnrollmentView
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.enrollments.views import (
     ApiKeyPermissionMixIn,
@@ -402,19 +401,20 @@ class BulkEnrollView(APIView, ApiKeyPermissionMixIn):
     def post(self, request):
         serializer = BulkEnrollmentSerializer(data=request.data)
         if serializer.is_valid():
-            request._request.POST = request.data  # pylint: disable=protected-access
             response_dict = {
                 "auto_enroll": serializer.data.get("auto_enroll"),
                 "email_students": serializer.data.get("email_students"),
                 "action": serializer.data.get("action"),
                 "courses": {},
             }
+            view = StudentsUpdateEnrollmentView()
             for course in serializer.data.get("courses"):
-                response = students_update_enrollment(
-                    request._request,  # pylint: disable=protected-access
+                response_dict["courses"][course] = view._process_student_enrollment(  # pylint: disable=protected-access
+                    user=request.user,
                     course_id=course,
+                    data=request.data,
+                    secure=request.is_secure(),
                 )
-                response_dict["courses"][course] = json.loads(response.content.decode("utf-8"))
             return Response(data=response_dict, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
## Description

This replaces the import of `students_update_enrollment` with `StudentsUpdateEnrollmentView` in views.py. The original function was refactored into a DRF APIView in
https://github.com/openedx/openedx-platform/commit/cdf508354436d3ab28f3d6b8936c3d7ddfb176d2

This commit updated the relevant code and it's usage to match this change.

Internal-ref: https://tasks.opencraft.com/browse/BB-10583

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Follow the testing instruction from https://github.com/open-craft/legacy-appsembler-api/blob/main/docs/manual-test-plan.md making use of the Yaak API Client's workspace in the same directory - `yaak-workspace.json`

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.

## Pre-merge checklist:

- [x] `make format` has been run
- [x] This has been manually installed in a Tutor devstack and:
  - [x] manual testing steps have been followed (as described in ./docs/manual-test-plan.md)
  - [x] `make test_migrations` has been run
